### PR TITLE
Add id and label to explorerConfig PEDS-567

### DIFF
--- a/templates/pcdc.json
+++ b/templates/pcdc.json
@@ -118,6 +118,8 @@
   },
   "explorerConfig": [
     {
+      "id": 1,
+      "label": "data",
       "charts": {
         "sex": {
           "chartType": "bar",


### PR DESCRIPTION
Ticket: [PEDS-567](https://pcdc.atlassian.net/browse/PEDS-567)

This PR makes adds newly required `id` and optional `label` options to `explorerConfig`.

Related: https://github.com/chicagopcdc/data-portal/pull/257.