### PR TITLE
Add CSRF check for gearbox local compose setup GEAR-216

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -121,14 +121,23 @@ http {
         }
         
         location /user/ {
+            if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+            }
             proxy_pass http://fence-service/;
         }
 
         location /gearbox/ {
+            if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+            }
             proxy_pass http://gearbox-service/;
         }
 
         location /gearbox-admin/ {
+            if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+            }
             rewrite ^/gearbox-admin/(.*) /$1 break;
             proxy_pass http://gearbox-service;
             proxy_redirect http://$host/ https://$host/gearbox-admin/;

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,6 +93,13 @@ http {
         large_client_header_buffers 4 8k;
         client_header_buffer_size 4k;
 
+        # Set cookie for CSRF token
+        set $csrf_token "$request_id$request_length$request_time$time_iso8601";
+        if ($cookie_csrftoken) {
+            set $csrf_token "$cookie_csrftoken";
+        }
+        add_header Set-Cookie "csrftoken=$csrf_token;Path=/;Secure;SameSite=Lax";
+
         #
         # CSRF check
         # This block requires a csrftoken for all POST requests.
@@ -112,7 +119,7 @@ http {
         location / {
             proxy_pass http://portal-service/;
         }
-
+        
         location /user/ {
             proxy_pass http://fence-service/;
         }


### PR DESCRIPTION
Ticket: [GEAR-216](https://pcdc.atlassian.net/browse/GEAR-216)

This PR adds CSRF check to nginx configuration for GEARBOx docker-compose stack. This is to better match the local dev setup with cloud deployment setup.