### PR TITLE
Add server-side survival configuration in settings script PEDS-836

### DIFF
--- a/templates/PcdcAnalysisTools_settings.py
+++ b/templates/PcdcAnalysisTools_settings.py
@@ -3,9 +3,12 @@ from os import environ
 import config_helper
 from pcdcutils.environment import is_env_enabled
 
-APP_NAME='PcdcAnalysisTools'
+APP_NAME = 'PcdcAnalysisTools'
+
+
 def load_json(file_name):
-  return config_helper.load_json(file_name, APP_NAME)
+    return config_helper.load_json(file_name, APP_NAME)
+
 
 conf_data = load_json('creds.json')
 config = app.config
@@ -37,8 +40,10 @@ config["PSQLGRAPH"] = {
 }
 
 config['HMAC_ENCRYPTION_KEY'] = conf_data.get('hmac_key', '{{hmac_key}}')
-config['FLASK_SECRET_KEY'] = conf_data.get('gdcapi_secret_key', '{{gdcapi_secret_key}}')
-config['PSQL_USER_DB_CONNECTION'] = 'postgresql://%s:%s@%s:5432/%s' % tuple([ conf_data.get(key, key) for key in ['fence_username', 'fence_password', 'fence_host', 'fence_database']])
+config['FLASK_SECRET_KEY'] = conf_data.get(
+    'gdcapi_secret_key', '{{gdcapi_secret_key}}')
+config['PSQL_USER_DB_CONNECTION'] = 'postgresql://%s:%s@%s:5432/%s' % tuple([conf_data.get(
+    key, key) for key in ['fence_username', 'fence_password', 'fence_host', 'fence_database']])
 config['OIDC_ISSUER'] = 'https://%s/user' % conf_data['hostname']
 
 config['OAUTH2'] = {
@@ -55,7 +60,7 @@ config['OAUTH2'] = {
     # deprecated key values, should be removed after all commons use new oidc
     'internal_oauth_provider': 'http://fence-service/oauth2/',
     'oauth_provider': 'https://%s/user/oauth2/' % conf_data['hostname'],
-    'redirect_uri': 'https://%s/api/v0/oauth2/authorize'  % conf_data['hostname']
+    'redirect_uri': 'https://%s/api/v0/oauth2/authorize' % conf_data['hostname']
 }
 
 # trailing slash intentionally omitted
@@ -71,6 +76,14 @@ if environ.get('DICTIONARY_URL'):
     config['DICTIONARY_URL'] = environ.get('DICTIONARY_URL')
 else:
     config['PATH_TO_SCHEMA_DIR'] = environ.get('PATH_TO_SCHEMA_DIR')
+
+config['SURVIVAL'] = {
+    'consortium': ["INSTRuCT"],
+    'result': {
+        'risktable': True,
+        'survival': True
+    }
+}
 
 app_init(app)
 application = app


### PR DESCRIPTION
Ticket: [PEDS-836](https://pcdc.atlassian.net/browse/PEDS-836)

This PR modifies the settings script for the `PcdcAnalysisTools` service to use server-side survival configuration for the local development setup. For it to take effect, this change must be coupled with a corresponding change to the `PcdcAnalysisTools` service (https://github.com/chicagopcdc/PcdcAnalysisTools/pull/57).